### PR TITLE
Fix header access in csv monitor

### DIFF
--- a/election-results-listener/csv-monitor.ts
+++ b/election-results-listener/csv-monitor.ts
@@ -50,7 +50,7 @@ export async function csvMonitor() {
   if (!exists) {
     const electionsData = await getCsvData(csvData);
     const results = calcVotesResults(electionsData, blockPercentage, agreements);
-    const time = new Date(fetchRes.headers['last-modified'] ?? '').toJSON();
+    const time = new Date(fetchRes.headers.get('last-modified') ?? '').toJSON();
     await uploadResults(results, currElections, time);
     await uploadCsv(csvData, currElections, time);
   }


### PR DESCRIPTION
## Summary
- use `Headers.get()` when reading Last-Modified in csv monitor

## Testing
- `npm test`
- `npx eslint ./**/*.ts ./elections-client/**/*.js`


------
https://chatgpt.com/codex/tasks/task_e_6848549db2b883319b09ee32e4f029e2