### PR TITLE
Add sum check in election tests

### DIFF
--- a/election-results-listener/__tests__/calc-elections.test.ts
+++ b/election-results-listener/__tests__/calc-elections.test.ts
@@ -118,6 +118,7 @@ describe('baderOffer', () => {
         mandats: 10,
       },
     });
+    assert.equal(sumBy(Object.values(res), 'mandats'), 20);
   });
 });
 
@@ -152,6 +153,7 @@ describe('ceilRound', () => {
         mandats: 10,
       },
     });
+    assert.equal(sumBy(Object.values(res), 'mandats'), 20);
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure sum of `mandats` equals total in algorithm tests

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486c5b9c3083319129f3e2ea6527f9