### PR TITLE
Fix convertToAgreements test wording

### DIFF
--- a/election-results-listener/__tests__/calc-elections.test.ts
+++ b/election-results-listener/__tests__/calc-elections.test.ts
@@ -34,7 +34,7 @@ describe('convertToAgreements', () => {
     });
   });
 
-  it('should not convert agreements if there are no votes', () => {
+  it('should ignore agreement pairs when a party is missing', () => {
     const res = convertToAgreements([['a', 'b'], ['c', 'd']], {
       a: {
         votes: 12345,


### PR DESCRIPTION
## Summary
- clarify test description when agreement pairs are skipped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486c5a5d8083319664c681ca219cd2