### PR TITLE
Fix csv monitor header usage

### DIFF
--- a/election-results-listener/csv-monitor.ts
+++ b/election-results-listener/csv-monitor.ts
@@ -50,7 +50,10 @@ export async function csvMonitor() {
   if (!exists) {
     const electionsData = await getCsvData(csvData);
     const results = calcVotesResults(electionsData, blockPercentage, agreements);
-    const time = new Date(fetchRes.headers.get('last-modified') ?? '').toJSON();
+    const lastModifiedHeader = fetchRes.headers.get('last-modified');
+    const time = (lastModifiedHeader
+      ? new Date(lastModifiedHeader)
+      : new Date()).toJSON();
     await uploadResults(results, currElections, time);
     await uploadCsv(csvData, currElections, time);
   }


### PR DESCRIPTION
## Summary
- use `Headers.get()` for last-modified header
- handle missing header with Date fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486c57e9d8833187c7779832881c33