### PR TITLE
Fix finish text in scripts

### DIFF
--- a/infra/CD/deploy.sh
+++ b/infra/CD/deploy.sh
@@ -11,4 +11,4 @@ rm -f client.zip && \
 zip -rq9 client.zip ./elections-client && \
 npm run update-s3 && \
 npm run clear-cache $1 && \
-echo finnish deploy!
+echo finish deploy!

--- a/infra/CD/update-s3.ts
+++ b/infra/CD/update-s3.ts
@@ -21,7 +21,7 @@ async function main() {
       'public-read',
     );
   }));
-  console.log('finnish');
+  console.log('finish');
 
   await upload(clientCodeName, 'client.zip', './client.zip', 'public-read');
 }


### PR DESCRIPTION
## Summary
- correct 'finish' spelling in update-s3 script
- echo `finish deploy!` when deploy completes

## Testing
- `npm run type-check`
- `npm run lint:test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486c5167a883318975be2d4b9bdcab